### PR TITLE
Change TestThreadPoolPublishModelFactory to deterministic implementation

### DIFF
--- a/metrics/metrics-core/src/test/java/org/apache/servicecomb/metrics/core/publish/TestInvocationPublishModelFactory.java
+++ b/metrics/metrics-core/src/test/java/org/apache/servicecomb/metrics/core/publish/TestInvocationPublishModelFactory.java
@@ -30,7 +30,6 @@ import org.apache.servicecomb.metrics.core.InvocationMetersInitializer;
 import org.apache.servicecomb.metrics.core.publish.model.DefaultPublishModel;
 import org.apache.servicecomb.swagger.invocation.InvocationType;
 import org.apache.servicecomb.swagger.invocation.Response;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.core.env.Environment;
@@ -40,6 +39,8 @@ import com.google.common.eventbus.EventBus;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.vertx.core.json.Json;
+
+import org.skyscreamer.jsonassert.JSONAssert;
 
 public class TestInvocationPublishModelFactory {
   EventBus eventBus = new EventBus();
@@ -60,7 +61,7 @@ public class TestInvocationPublishModelFactory {
   Environment environment = Mockito.mock(Environment.class);
 
   @Test
-  public void createDefaultPublishModel() {
+  public void createDefaultPublishModel() throws Exception {
     Mockito.when(environment.getProperty(METRICS_WINDOW_TIME, int.class, DEFAULT_METRICS_WINDOW_TIME))
         .thenReturn(DEFAULT_METRICS_WINDOW_TIME);
     Mockito.when(environment.getProperty(
@@ -170,8 +171,8 @@ public class TestInvocationPublishModelFactory {
             }
           }
         """;
-    Assertions.assertEquals(Json.encodePrettily(Json.decodeValue(expect, Object.class)),
-        Json.encodePrettily(model.getConsumer()));
+    JSONAssert.assertEquals(Json.encodePrettily(Json.decodeValue(expect, Object.class)),
+        Json.encodePrettily(model.getConsumer()), false);
 
     expect = """
         {
@@ -269,8 +270,8 @@ public class TestInvocationPublishModelFactory {
           }
         }
         """;
-    Assertions.assertEquals(Json.encodePrettily(Json.decodeValue(expect, Object.class)),
-        Json.encodePrettily(model.getProducer()));
+    JSONAssert.assertEquals(Json.encodePrettily(Json.decodeValue(expect, Object.class)),
+        Json.encodePrettily(model.getProducer()), false);
   }
 
   protected void prepareInvocation() {

--- a/metrics/metrics-core/src/test/java/org/apache/servicecomb/metrics/core/publish/TestInvocationPublishModelFactory.java
+++ b/metrics/metrics-core/src/test/java/org/apache/servicecomb/metrics/core/publish/TestInvocationPublishModelFactory.java
@@ -30,6 +30,7 @@ import org.apache.servicecomb.metrics.core.InvocationMetersInitializer;
 import org.apache.servicecomb.metrics.core.publish.model.DefaultPublishModel;
 import org.apache.servicecomb.swagger.invocation.InvocationType;
 import org.apache.servicecomb.swagger.invocation.Response;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.core.env.Environment;
@@ -39,8 +40,6 @@ import com.google.common.eventbus.EventBus;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.vertx.core.json.Json;
-
-import org.skyscreamer.jsonassert.JSONAssert;
 
 public class TestInvocationPublishModelFactory {
   EventBus eventBus = new EventBus();
@@ -61,12 +60,12 @@ public class TestInvocationPublishModelFactory {
   Environment environment = Mockito.mock(Environment.class);
 
   @Test
-  public void createDefaultPublishModel() throws Exception {
+  public void createDefaultPublishModel() {
     Mockito.when(environment.getProperty(METRICS_WINDOW_TIME, int.class, DEFAULT_METRICS_WINDOW_TIME))
-        .thenReturn(DEFAULT_METRICS_WINDOW_TIME);
+            .thenReturn(DEFAULT_METRICS_WINDOW_TIME);
     Mockito.when(environment.getProperty(
-            CONFIG_LATENCY_DISTRIBUTION_MIN_SCOPE_LEN, int.class, 7))
-        .thenReturn(7);
+                    CONFIG_LATENCY_DISTRIBUTION_MIN_SCOPE_LEN, int.class, 7))
+            .thenReturn(7);
     Mockito.when(environment.getProperty(CONFIG_LATENCY_DISTRIBUTION, String.class)).thenReturn("0,1,100");
 
     invocationMetersInitializer.init(meterRegistry, eventBus, new MetricsBootstrapConfig(environment));
@@ -171,8 +170,8 @@ public class TestInvocationPublishModelFactory {
             }
           }
         """;
-    JSONAssert.assertEquals(Json.encodePrettily(Json.decodeValue(expect, Object.class)),
-        Json.encodePrettily(model.getConsumer()), false);
+    Assertions.assertEquals(Json.encodePrettily(Json.decodeValue(expect, Object.class)),
+            Json.encodePrettily(model.getConsumer()));
 
     expect = """
         {
@@ -270,8 +269,8 @@ public class TestInvocationPublishModelFactory {
           }
         }
         """;
-    JSONAssert.assertEquals(Json.encodePrettily(Json.decodeValue(expect, Object.class)),
-        Json.encodePrettily(model.getProducer()), false);
+    Assertions.assertEquals(Json.encodePrettily(Json.decodeValue(expect, Object.class)),
+            Json.encodePrettily(model.getProducer()));
   }
 
   protected void prepareInvocation() {

--- a/metrics/metrics-core/src/test/java/org/apache/servicecomb/metrics/core/publish/TestThreadPoolPublishModelFactory.java
+++ b/metrics/metrics-core/src/test/java/org/apache/servicecomb/metrics/core/publish/TestThreadPoolPublishModelFactory.java
@@ -24,7 +24,6 @@ import org.apache.servicecomb.foundation.common.utils.JsonUtils;
 import org.apache.servicecomb.foundation.metrics.MetricsBootstrapConfig;
 import org.apache.servicecomb.metrics.core.ThreadPoolMetersInitializer;
 import org.apache.servicecomb.metrics.core.publish.model.DefaultPublishModel;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
@@ -35,6 +34,8 @@ import org.mockito.Mockito;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.skyscreamer.jsonassert.JSONAssert;
 
 @ExtendWith(MockitoExtension.class)
 @TestMethodOrder(MethodOrderer.MethodName.class)
@@ -61,9 +62,9 @@ public class TestThreadPoolPublishModelFactory {
     PublishModelFactory factory = new PublishModelFactory(registry.getMeters());
     DefaultPublishModel model = factory.createDefaultPublishModel();
 
-    Assertions.assertEquals(
+    JSONAssert.assertEquals(
         """
             {"test":{"avgTaskCount":0.0,"avgCompletedTaskCount":0.0,"currentThreadsBusy":0,"maxThreads":0,"poolSize":0,"corePoolSize":0,"queueSize":10,"rejected":0.0}}""",
-        JsonUtils.writeValueAsString(model.getThreadPools()));
+        JsonUtils.writeValueAsString(model.getThreadPools()), false);
   }
 }


### PR DESCRIPTION
**Issue:** The method `createDefaultPublishModel()` in `TestThreadPoolPublishModelFactory` compares JSONs to verify that the default object is properly created. However, since JSONs are unordered collections, when converted to strings the parameter order may not be preserved. This test uses a hard-coded JSON string as the expected correct value, but the test could fail if the parameters from the test object are stringified in a different order than the expected string. For another example of this issue being addressed, see this [previous merged PR](https://github.com/apache/servicecomb-java-chassis/pull/4633).

This test was flagged via the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool, which detects potentially unreliable tests due to underlying Java API assumptions. To see the Nondex output for this tests, you can run:
```
mvn -pl metrics/metrics-core edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest="org.apache.servicecomb.metrics.core.publish.TestThreadPoolPublishModelFactory#createDefaultPublishModel"
```

**Fix:** The fix I implemented uses [JSONAssert's](https://jsonassert.skyscreamer.org/apidocs/org/skyscreamer/jsonassert/JSONAssert.html) `assertEquals()` method, using non-strict checking (which ignores parameter ordering). This compares the JSON strings without enforcing parameter ordering, which removes the potentially unreliable nature of these tests. **This library is already included within the spring-boot dependency, which is already used in the project, so there's no need to update the pom file.** Rerunning Nondex shows a passing result.

I believe this is the simplest fix, but it seems someone else has already fixed a similar test in a different way: https://github.com/apache/servicecomb-java-chassis/pull/4633 using JsonNode trees. If it's better to keep code consistency, I can also implement the same methodology here.

**PR Checklist:**
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SCB) filed for the change (usually before you start working on it). Trivial changes like typos do not require a JIRA issue. Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] Format the pull request title like [SCB-XXX] Fixes bug in ApproximateQuantiles, where you replace SCB-XXX with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run mvn clean install -Pit to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
